### PR TITLE
Changed BeautifulSoup parser to html5lib

### DIFF
--- a/SpiffyTitles/plugin.py
+++ b/SpiffyTitles/plugin.py
@@ -1239,7 +1239,7 @@ class SpiffyTitles(callbacks.Plugin):
         """
         Retrieves value of <title> tag from HTML
         """
-        soup = BeautifulSoup(html, "lxml")
+        soup = BeautifulSoup(html, "html5lib")
 
         if soup is not None:
             """


### PR DESCRIPTION
This makes it possible for SpiffyTitles to decode html entities like &abreve; &acirc; &comma; etc.