### PR TITLE
Fix integer division on Python 3.

### DIFF
--- a/SpiffyTitles/plugin.py
+++ b/SpiffyTitles/plugin.py
@@ -6,6 +6,8 @@
 #
 ###
 
+from __future__ import division
+
 from supybot.commands import *
 import supybot.ircmsgs as ircmsgs
 import supybot.ircutils as ircutils
@@ -1041,7 +1043,7 @@ class SpiffyTitles(callbacks.Plugin):
             else:
                 age = '{}d'.format(age_days % 365)
                 if age_days > 365:
-                    age = '{}y, '.format(age_days / 365) + age
+                    age = '{}y, '.format(age_days // 365) + age
                 age = age + " ago"
             if link_type == "thread":
                 link_type = "linkThread"


### PR DESCRIPTION
The `__future__` import backports the integer division syntax to Python 2, so the behavior of the plugin on Python 2 is unchanged.