### PR TITLE
SpiffyTitles: Add Imdb API key

### DIFF
--- a/SpiffyTitles/README.md
+++ b/SpiffyTitles/README.md
@@ -118,6 +118,8 @@ Queries the [OMDB API](http://www.omdbapi.com) to get additional information abo
 
 `imdbHandlerEnabled` - Whether to show additional information about [IMDB](http://imdb.com) links
 
+`imdbKey` - Omdb key used for imdb - Get one at [OMDBAPI](https://www.omdbapi.com/apikey.aspx)
+
 `imdbTemplate` - This is the template used for [IMDB](http://imdb.com) links
 
 Default value: `^ {{Title}} ({{Year}}, {{Country}}) - Rating: {{imdbRating}} ::  {{Plot}}`

--- a/SpiffyTitles/config.py
+++ b/SpiffyTitles/config.py
@@ -138,6 +138,10 @@ conf.registerChannelValue(SpiffyTitles, 'imgurAlbumTemplate',
 conf.registerGlobalValue(SpiffyTitles, 'youtubeDeveloperKey',
                         registry.String("", _("""Youtube developer key - required for Youtube handler."""), private=True))
 
+# Omdb API
+conf.registerGlobalValue(SpiffyTitles, 'imdbKey',
+                        registry.String("", _("""Omdb API key - required for Imdb handler."""), private=True))
+
 # Link cache lifetime
 conf.registerGlobalValue(SpiffyTitles, 'linkCacheLifetimeInSeconds',
                         registry.Integer(60, _("""Link cache lifetime in seconds""")))

--- a/SpiffyTitles/plugin.py
+++ b/SpiffyTitles/plugin.py
@@ -833,6 +833,11 @@ class SpiffyTitles(callbacks.Plugin):
 
             return self.handler_default(url, channel)
 
+        imdb_key = self.registryValue("imdbKey")
+        if not imdb_key:
+            log.info("SpiffyTitles: no Imdb key set! Check https://www.omdbapi.com/apikey.aspx .")
+            return None
+
         # Don't care about query strings
         if "?" in url:
             url = url.split("?")[0]
@@ -840,7 +845,7 @@ class SpiffyTitles(callbacks.Plugin):
         # We can only accommodate a specific format of URL here
         if "/title/" in url:
             imdb_id = url.split("/title/")[1].rstrip("/")
-            omdb_url = "http://www.omdbapi.com/?i=%s&plot=short&r=json&tomatoes=true" % (imdb_id)
+            omdb_url = "http://www.omdbapi.com/?i=%s&apikey=%s&plot=short&r=json&tomatoes=true" % (imdb_id, imdb_key)
 
             try:
                 request = requests.get(omdb_url, timeout=10, headers=headers)


### PR DESCRIPTION
Looks like Imdb now requires an API key:
SpiffyTitles OMDB API 401 - {"Response":"False","Error":"No API key provided."}
