### PR TITLE
SpiffyTitles: remove a leftover use of 'parse_qsl' from module 'cgi'

### DIFF
--- a/SpiffyTitles/plugin.py
+++ b/SpiffyTitles/plugin.py
@@ -16,7 +16,6 @@ import sys
 from bs4 import BeautifulSoup
 import random
 import json
-import cgi
 import datetime
 from jinja2 import Template
 from datetime import timedelta
@@ -600,7 +599,7 @@ class SpiffyTitles(callbacks.Plugin):
             if domain == "youtu.be":
                 video_id = path.split("/")[1]
             else:
-                parsed = cgi.parse_qsl(info.query)
+                parsed = parse_qsl(info.query)
                 params = dict(parsed)
 
                 if "v" in params:


### PR DESCRIPTION
that was discovered when I went from from Python 3.5 to 3.9.
It was removed in 3.8 from 'cgi':
https://docs.python.org/3.8/whatsnew/3.8.html#api-and-feature-removals
https://docs.python.org/3.7/library/cgi.html#cgi.parse_qsl